### PR TITLE
Replace openssl with haskell-native functions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: freckle/stack-action@v4
+    - uses: actions/checkout@v4
+    - uses: freckle/stack-action@v5
 

--- a/paddle.cabal
+++ b/paddle.cabal
@@ -49,20 +49,25 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      HsOpenSSL
-    , aeson
+      aeson
+    , asn1-encoding
+    , asn1-types
     , base >=4.7 && <5
     , base64-bytestring
     , bytestring
     , containers
+    , crypton
+    , crypton-x509
     , http-api-data
     , http-client
-    , time
+    , memory
+    , pem
     , protolude
     , scientific
     , servant
     , servant-client
     , servant-client-core
+    , time
   default-language: Haskell2010
   default-extensions:
     OverloadedStrings

--- a/src/Paddle/Env.hs
+++ b/src/Paddle/Env.hs
@@ -2,9 +2,12 @@ module Paddle.Env where
 
 import Prelude ()
 import Protolude
-import qualified OpenSSL as SSL
-import qualified OpenSSL.EVP.PKey as SSL
-import qualified OpenSSL.PEM as SSL
+import qualified Data.PEM as PEM
+import qualified Data.X509 as X509
+import qualified Data.ASN1.BinaryEncoding as ASN1
+import qualified Data.ASN1.Encoding as ASN1
+import qualified Data.ASN1.Types as ASN1
+import qualified Crypto.PubKey.RSA as RSA
 
 data PaddleSecrets = PaddleSecrets
   { paddlePublicKey :: Text -- ^ despite being a public key this must remain secret or anyone who has it can call our webhooks
@@ -14,14 +17,23 @@ data PaddleSecrets = PaddleSecrets
 
 -- | Various keys for Paddle. These should all be kept secret.
 data Env = Env
-  { pctxPubKey :: SSL.SomePublicKey
+  { pctxPubKey :: RSA.PublicKey
   , pctxVendorId :: Int
   , pctxApiKey :: Text
   } deriving (Eq)
 
 init :: (MonadIO m) => PaddleSecrets -> m Env
 init secrets = do
-  pubKey <- liftIO $ SSL.withOpenSSL $ SSL.readPublicKey (toS (paddlePublicKey secrets))
+  pubKey <- case PEM.pemParseBS (encodeUtf8 (paddlePublicKey secrets)) of
+    Right [pem] -> case ASN1.decodeASN1' ASN1.DER (PEM.pemContent pem) of
+      Right asn1 -> case ASN1.fromASN1 asn1 of
+        Right (X509.PubKeyRSA rsaKey, _) -> return rsaKey
+        Right _ -> panic "Public key is not RSA"
+        Left err -> panic $ "Failed to parse public key from ASN1: " <> show err
+      Left err -> panic $ "Failed to decode ASN1: " <> show err
+    Right [] -> panic "No PEM objects found"
+    Right _ -> panic "Multiple PEM objects found, expected one"
+    Left err -> panic $ "Failed to parse PEM: " <> show err
   return Env
     { pctxPubKey = pubKey
     , pctxVendorId = paddleVendorId secrets

--- a/src/Paddle/Env.hs
+++ b/src/Paddle/Env.hs
@@ -39,13 +39,12 @@ parseRSAPublicKey pemText = do
     Right _ -> Left "Public key is not RSA"
     Left err -> Left $ "ASN1 parse error: " <> show err
 
-init :: (MonadIO m) => PaddleSecrets -> m Env
+init :: (MonadIO m) => PaddleSecrets -> m (Either Text Env)
 init secrets = do
-  pubKey <- case parseRSAPublicKey (paddlePublicKey secrets) of
-    Right key -> return key
-    Left err -> panic err
-  return Env
-    { pctxPubKey = pubKey
-    , pctxVendorId = paddleVendorId secrets
-    , pctxApiKey = paddleApiKey secrets
-    }
+  return $ do
+    pubKey <- parseRSAPublicKey (paddlePublicKey secrets)
+    return Env
+      { pctxPubKey = pubKey
+      , pctxVendorId = paddleVendorId secrets
+      , pctxApiKey = paddleApiKey secrets
+      }

--- a/src/Paddle/WebHook/Signature.hs
+++ b/src/Paddle/WebHook/Signature.hs
@@ -1,19 +1,18 @@
-module Paddle.WebHook.Signature where 
+module Paddle.WebHook.Signature where
 
-import Prelude ()
-import qualified Prelude
-import Protolude hiding (toS)
-import Protolude.Conv
-import qualified Data.Map.Strict as M
+import qualified Crypto.Hash as Hash
+import qualified Crypto.PubKey.RSA.PKCS15 as RSA
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Builder as BSB
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as LBS
-import qualified OpenSSL as SSL
-import qualified OpenSSL.EVP.Digest as SSL
-import qualified OpenSSL.EVP.Verify as SSL
-import qualified Data.ByteString.Base64 as Base64
-
-import Paddle.Env (Env(..))
+import qualified Data.Map.Strict as M
+import Paddle.Env (Env (..))
+import Protolude hiding (toS)
+import Protolude.Conv
+import Prelude ()
+import qualified Prelude
 
 type SignatureBody = M.Map Text [Text]
 
@@ -21,34 +20,34 @@ type SignatureBody = M.Map Text [Text]
 serializeFields :: M.Map ByteString ByteString -> ByteString
 serializeFields fields =
   let serializeString str = "s:" <> BSB.intDec (BS.length str) <> ":\"" <> BSB.byteString str <> "\";"
-  in LBS.toStrict $ BSB.toLazyByteString $
-       "a:" <> BSB.intDec (M.size fields) <> ":{" <>
-         foldMap (\(key, value) -> serializeString key <> serializeString value) (M.toAscList fields)
-       <> "}"
+   in LBS.toStrict $
+        BSB.toLazyByteString $
+          "a:"
+            <> BSB.intDec (M.size fields)
+            <> ":{"
+            <> foldMap (\(key, value) -> serializeString key <> serializeString value) (M.toAscList fields)
+            <> "}"
 
 -- Given all fields in webhook request, validate against their signature
 validateSignature :: (MonadIO m) => Env -> SignatureBody -> m (Either Text ())
 validateSignature env rawFields =
-  let 
-    fields :: M.Map ByteString ByteString
-    fields =  M.fromList $ map (\(k ,v) -> (toS k, toS (maybe "" identity (head v)))) (M.toList rawFields)
+  let fields :: M.Map ByteString ByteString
+      fields = M.fromList $ map (\(k, v) -> (toS k, toS (maybe "" identity (head v)))) (M.toList rawFields)
 
-    signature :: Either Prelude.String ByteString
-    signature = maybeToEither "Missing signature field." (M.lookup "p_signature" fields)
+      signature :: Either Prelude.String ByteString
+      signature = maybeToEither "Missing signature field." (M.lookup "p_signature" fields)
 
-    signatureDecode :: ByteString -> Either Prelude.String ByteString
-    signatureDecode = Base64.decode . toS
+      signatureDecode :: ByteString -> Either Prelude.String ByteString
+      signatureDecode = Base64.decode . toS
 
-    -- we need to verify the signature against the PHP-serialized request parameters (excluding p_signature)
-    -- here's a gist that does it in Swift: https://gist.github.com/drewmccormack/a51b18ffeda8f596a11a8623481344d8
-    serialize sig = Right (serializeFields (M.delete "p_signature" fields), sig)
-  in do
-    case signature >>= signatureDecode >>= serialize of
-      Left err -> return $ Left (toS err)
-      Right (serializedFields, sigBytes) -> liftIO $ SSL.withOpenSSL $ do
-        Just sha1 <- SSL.getDigestByName "SHA1"
-        verifyRes <- SSL.verifyBS sha1 sigBytes (pctxPubKey env) serializedFields
-
-        if (verifyRes == SSL.VerifySuccess)
-        then return $ Right ()
-        else return $ Left "Request has invalid signature"
+      -- we need to verify the signature against the PHP-serialized request parameters (excluding p_signature)
+      -- here's a gist that does it in Swift: https://gist.github.com/drewmccormack/a51b18ffeda8f596a11a8623481344d8
+      serialize sig = Right (serializeFields (M.delete "p_signature" fields), sig)
+   in do
+        case signature >>= signatureDecode >>= serialize of
+          Left err -> return $ Left (toS err)
+          Right (serializedFields, sigBytes) -> do
+            let sha1Hash = Hash.hash serializedFields :: Hash.Digest Hash.SHA1
+            if RSA.verify (Just Hash.SHA1) (pctxPubKey env) (BA.convert sha1Hash) sigBytes
+              then return $ Right ()
+              else return $ Left "Request has invalid signature"

--- a/src/Paddle/WebHook/Signature.hs
+++ b/src/Paddle/WebHook/Signature.hs
@@ -19,14 +19,17 @@ type SignatureBody = M.Map Text [Text]
 -- | Serialize a map of fields for signature verification
 serializeFields :: M.Map ByteString ByteString -> ByteString
 serializeFields fields =
-  let serializeString str = "s:" <> BSB.intDec (BS.length str) <> ":\"" <> BSB.byteString str <> "\";"
-   in LBS.toStrict $
-        BSB.toLazyByteString $
-          "a:"
-            <> BSB.intDec (M.size fields)
-            <> ":{"
-            <> foldMap (\(key, value) -> serializeString key <> serializeString value) (M.toAscList fields)
-            <> "}"
+  LBS.toStrict $
+    BSB.toLazyByteString $
+      "a:"
+        <> BSB.intDec (M.size fields)
+        <> ":{"
+        <> foldMap (\(key, value) -> serializeString key <> serializeString value) (M.toAscList fields)
+        <> "}"
+  where
+    serializePair (k, v) = serializeString k <> serializeString v
+    serializeString s =
+      "s:" <> BSB.intDec (BS.length s) <> ":\"" <> BSB.byteString s <> "\";"
 
 -- Given all fields in webhook request, validate against their signature
 validateSignature :: (MonadIO m) => Env -> SignatureBody -> m (Either Text ())


### PR DESCRIPTION
An alternative to HsOpenSSL, which uses deprecated APIs and needs a lot of work.

~Could really use tests to make sure it works.~ Test was added to the master branch first, then modified to work here.